### PR TITLE
LazyPath.path is deprecated, Use Build.path() instead

### DIFF
--- a/thirdparty/strpool.h
+++ b/thirdparty/strpool.h
@@ -498,10 +498,10 @@ struct strpool_t {
 #define _CRT_NONSTDC_NO_DEPRECATE
 #define _CRT_SECURE_NO_WARNINGS
 #include <string.h>
-#if !defined(sternicmp)
-#define STRPOOL_STRNICMP(s1, s2, len) (_strnicmp(s1, s2, len))
-#else
+#if defined(strnicmp)
 #define STRPOOL_STRNICMP(s1, s2, len) (strnicmp(s1, s2, len))
+#else
+#define STRPOOL_STRNICMP(s1, s2, len) (_strnicmp(s1, s2, len))
 #endif
 #else
 #include <string.h>


### PR DESCRIPTION
I also adjusted the apple logic to compile apple.m from within zig-cache to avoid polluting the src folder with generated code (this also avoids the need to explicitly add a dependency on the copy step; `addCSourceFile` will do that automatically when you pass in a `LazyPath.generated`)