### PR TITLE
Use x86_64-windows-gnu by default on windows

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -335,24 +335,19 @@ pub fn build(b: *std.Build) void {
         }
     }
 
-    const cargo_build = b.addSystemCommand(&.{
-        "cargo",
-        "build",
-        "--target",
-        rust_target,
-        "--profile",
-        if (optimize == .Debug) "dev" else "release",
+    const rust_lib_path = @import("build.crab").addCargoBuild(b, .{
+        .name = "libcrate.a",
+        .manifest_path = b.path("thirdparty/routing/Cargo.toml"),
+        .cargo_args = &.{
+            "--profile",
+            if (optimize == .Debug) "dev" else "release",
+            //"--quiet",
+        },
     });
-    cargo_build.stdio = .inherit;
-    cargo_build.setCwd(b.path("thirdparty/routing"));
-    digilogic.step.dependOn(&cargo_build.step);
-    digilogic_test.step.dependOn(&cargo_build.step);
 
-    const rust_profile = if (optimize == .Debug) "debug" else "release";
-    const library_path = b.fmt("thirdparty/routing/target/{s}/{s}", .{ rust_target, rust_profile });
-    digilogic.addLibraryPath(b.path(library_path));
+    digilogic.addLibraryPath(rust_lib_path.dirname());
     digilogic.linkSystemLibrary("digilogic_routing");
-    digilogic_test.addLibraryPath(b.path(library_path));
+    digilogic_test.addLibraryPath(rust_lib_path.dirname());
     digilogic_test.linkSystemLibrary("digilogic_routing");
 
     if (target.result.os.tag.isDarwin()) {

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -17,8 +17,8 @@
             .hash = "12208be74c8d4d86a323ba371a0e063dc87f9d4ce2b7c2b7e745e3bce99487ec11c7",
         },
         .@"build.crab" = .{
-            .url = "git+https://github.com/akarpovskii/build.crab#6f170fd7bc8845aeef58ff05c6d1ffa253445622",
-            .hash = "1220ac26da133ec83df00f0f0065f5cc74c8ac7bb2925096856ed27dce511ec6744a",
+            .url = "git+https://github.com/bcrist/build.crab#e6584ef1d50d70a7fd04b48c769f0bfb13e046ca",
+            .hash = "1220250870afb0635da169b7b9f67178e57e640c86ddf5fae9c0d7e07ef0980880ed",
         },
     },
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -16,5 +16,9 @@
             .url = "git+https://github.com/bcrist/globlin#5232937d014b63fc1d7e53a7a8751306696a64f1",
             .hash = "12208be74c8d4d86a323ba371a0e063dc87f9d4ce2b7c2b7e745e3bce99487ec11c7",
         },
+        .@"build.crab" = .{
+            .url = "git+https://github.com/akarpovskii/build.crab#6f170fd7bc8845aeef58ff05c6d1ffa253445622",
+            .hash = "1220ac26da133ec83df00f0f0065f5cc74c8ac7bb2925096856ed27dce511ec6744a",
+        },
     },
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -12,5 +12,9 @@
             .url = "git+https://github.com/bcrist/zig-compile-commands#20372137e6d63f39cece19ee1e91ae4a3151875c",
             .hash = "1220a2e71dce460ce3ebaca36565893bc14e8d89177ec568c5efd6444f03118cc090",
         },
+        .globlin = .{
+            .url = "git+https://github.com/bcrist/globlin#5232937d014b63fc1d7e53a7a8751306696a64f1",
+            .hash = "12208be74c8d4d86a323ba371a0e063dc87f9d4ce2b7c2b7e745e3bce99487ec11c7",
+        },
     },
 }

--- a/thirdparty/assetsys.h
+++ b/thirdparty/assetsys.h
@@ -7157,6 +7157,7 @@ void *mz_zip_extract_archive_file_to_heap(
 // 0x0603=Windows 8.1, 0x0A00=Windows 10
 #endif
 #define _WINSOCKAPI_
+#ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4668) // 'symbol' is not defined as a preprocessor
                                 // macro, replacing with '0' for 'directives'
@@ -7164,8 +7165,11 @@ void *mz_zip_extract_archive_file_to_heap(
                                 // specification are ignored
 #pragma warning(disable : 4255) // 'function' : no function prototype given:
                                 // converting '()' to '(void)'
+#endif
 #include <windows.h>
+#ifdef _MSC_VER
 #pragma warning(pop)
+#endif
 
 struct assetsys_internal_dir_entry_t {
   char name[MAX_PATH];

--- a/thirdparty/file_compat.h
+++ b/thirdparty/file_compat.h
@@ -555,8 +555,10 @@ static int fc_locale(char *locale, size_t locale_max) {
 #endif
 #include <windows.h>
 #include <Shlobj.h>
+#ifdef _MSC_VER
 #pragma comment(lib, "Shell32.lib")
 #pragma comment(lib, "Ole32.lib")
+#endif
 #include <stdlib.h> // wcstombs_s
 #if !defined(PATH_MAX)
 #  define PATH_MAX MAX_PATH

--- a/thirdparty/sokol_app.h
+++ b/thirdparty/sokol_app.h
@@ -2098,15 +2098,18 @@ inline void sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
     #include <windowsx.h>
     #include <shellapi.h>
     #if !defined(SOKOL_NO_ENTRY)    // if SOKOL_NO_ENTRY is defined, it's the applications' responsibility to use the right subsystem
+        #ifdef _MSC_VER
         #if defined(SOKOL_WIN32_FORCE_MAIN)
             #pragma comment (linker, "/subsystem:console")
         #else
             #pragma comment (linker, "/subsystem:windows")
         #endif
+        #endif
     #endif
     #include <stdio.h>  /* freopen_s() */
     #include <wchar.h>  /* wcslen() */
 
+    #ifdef _MSC_VER
     #pragma comment (lib, "kernel32")
     #pragma comment (lib, "user32")
     #pragma comment (lib, "shell32")    /* CommandLineToArgvW, DragQueryFileW, DragFinished */
@@ -2114,6 +2117,7 @@ inline void sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
     #if defined(SOKOL_D3D11)
         #pragma comment (lib, "dxgi")
         #pragma comment (lib, "d3d11")
+    #endif
     #endif
 
     #if defined(SOKOL_D3D11)

--- a/thirdparty/sokol_gfx.h
+++ b/thirdparty/sokol_gfx.h
@@ -4335,7 +4335,9 @@ inline int sg_append_buffer(sg_buffer buf_id, const sg_range& data) { return sg_
                 #endif
                 #include <windows.h>
                 #define _SOKOL_USE_WIN32_GL_LOADER (1)
+                #ifdef _MSC_VER
                 #pragma comment (lib, "kernel32")   // GetProcAddress()
+                #endif
             #endif
         #elif defined(__APPLE__)
             #include <TargetConditionals.h>

--- a/thirdparty/thread.h
+++ b/thirdparty/thread.h
@@ -637,8 +637,9 @@ struct thread_queue_t {
 #endif
 
 #if defined(_WIN32)
-
+#ifdef _MSC_VER
 #pragma comment(lib, "winmm.lib")
+#endif
 
 #define _CRT_NONSTDC_NO_DEPRECATE
 #define _CRT_SECURE_NO_WARNINGS
@@ -649,6 +650,7 @@ struct thread_queue_t {
 #endif
 
 #define _WINSOCKAPI_
+#ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4619)
 #pragma warning(disable : 4668) // 'symbol' is not defined as a preprocessor
@@ -657,8 +659,11 @@ struct thread_queue_t {
                                 // specification are ignored
 #pragma warning(disable : 4255) // 'function' : no function prototype given:
                                 // converting '()' to '(void)'
+#endif
 #include <windows.h>
+#ifdef _MSC_VER
 #pragma warning(pop)
+#endif
 
 #elif defined(__linux__) || defined(__APPLE__) || defined(__ANDROID__)
 
@@ -811,14 +816,18 @@ void thread_mutex_init(thread_mutex_t *mutex) {
 #if defined(_WIN32)
 
 // Compile-time size check
+#ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4214) // nonstandard extension used: bit field types
                                 // other than int
+#endif
   struct x {
     char thread_mutex_type_too_small
         : (sizeof(thread_mutex_t) < sizeof(CRITICAL_SECTION) ? 0 : 1);
   };
+#ifdef _MSC_VER
 #pragma warning(pop)
+#endif
 
   InitializeCriticalSectionAndSpinCount((CRITICAL_SECTION *)mutex, 32);
 
@@ -1188,14 +1197,18 @@ void *thread_atomic_ptr_load(thread_atomic_ptr_t *atomic) {
 void thread_atomic_ptr_store(thread_atomic_ptr_t *atomic, void *desired) {
 #if defined(_WIN32)
 
+#ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(                                                               \
   disable : 4302) // 'type cast' : truncation from 'void *' to 'LONG'
 #pragma warning(disable : 4311) // pointer truncation from 'void *' to 'LONG'
 #pragma warning(                                                               \
   disable : 4312) // conversion from 'LONG' to 'PVOID' of greater size
+#endif
   InterlockedExchangePointer(&atomic->ptr, desired);
+#ifdef _MSC_VER
 #pragma warning(pop)
+#endif
 
 #elif defined(__linux__) || defined(__APPLE__) || defined(__ANDROID__)
 
@@ -1210,14 +1223,18 @@ void thread_atomic_ptr_store(thread_atomic_ptr_t *atomic, void *desired) {
 void *thread_atomic_ptr_swap(thread_atomic_ptr_t *atomic, void *desired) {
 #if defined(_WIN32)
 
+#ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(                                                               \
   disable : 4302) // 'type cast' : truncation from 'void *' to 'LONG'
 #pragma warning(disable : 4311) // pointer truncation from 'void *' to 'LONG'
 #pragma warning(                                                               \
   disable : 4312) // conversion from 'LONG' to 'PVOID' of greater size
+#endif
   return InterlockedExchangePointer(&atomic->ptr, desired);
+#ifdef _MSC_VER
 #pragma warning(pop)
+#endif
 
 #elif defined(__linux__) || defined(__APPLE__) || defined(__ANDROID__)
 
@@ -1249,14 +1266,19 @@ void thread_timer_init(thread_timer_t *timer) {
 #if defined(_WIN32)
 
 // Compile-time size check
+#ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4214) // nonstandard extension used: bit field types
                                 // other than int
+#endif
+
   struct x {
     char thread_timer_type_too_small
         : (sizeof(thread_mutex_t) < sizeof(HANDLE) ? 0 : 1);
   };
+#ifdef _MSC_VER
 #pragma warning(pop)
+#endif
 
   TIMECAPS tc;
   if (timeGetDevCaps(&tc, sizeof(TIMECAPS)) == TIMERR_NOERROR)


### PR DESCRIPTION
Adds support for compiling with `x86_64-windows-gnu` instead of `x86_64-windows-msvc`, which means it shouldn't be necessary to have MSVC build tools installed anymore.

Also cleans up detection of the LLVM lib dir on macOS so that ASan should work with zig 0.13, which uses LLVM18.  Note: this part is untested!